### PR TITLE
Fix issue with options reference in ErrorParser [#1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf-sentry gem.
 
 ### Pending release
 
+- Fix issue with options reference in ErrorParser [#1]
+
 ### 0.1.0
 
 * Initial release

--- a/lib/gruf/sentry/error_parser.rb
+++ b/lib/gruf/sentry/error_parser.rb
@@ -40,7 +40,7 @@ module Gruf
       # @return [Array]
       #
       def error_classes
-        options.fetch(:error_classes, Gruf::Sentry.grpc_error_classes)
+        @options.fetch(:error_classes, Gruf::Sentry.grpc_error_classes)
       end
     end
   end


### PR DESCRIPTION
Fixes #1 by referencing options correctly as an instance variable.