### PR TITLE
Add Ruby 3.0 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,24 +13,24 @@ ruby_env: &ruby_env
     - image: circleci/ruby:<<parameters.ruby-version>>
 
 executors:
-  ruby_2_4:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "2.4.9"
-  ruby_2_5:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "2.5.7"
   ruby_2_6:
     <<: *ruby_env
     parameters:
       ruby-version:
         type: string
-        default: "2.6.5"
+        default: "2.6"
+  ruby_2_7:
+    <<: *ruby_env
+    parameters:
+      ruby-version:
+        type: string
+        default: "2.7"
+  ruby_3_0:
+    <<: *ruby_env
+    parameters:
+      ruby-version:
+        type: string
+        default: "3.0"
 
 commands:
   pre-setup:
@@ -39,6 +39,12 @@ commands:
       - checkout
   bundle-install:
     steps:
+      - run:
+          name: "Install bundler 1.17.3"
+          command: |
+            echo 'export BUNDLER_VERSION=1.17.3' >> $BASH_ENV
+            source $BASH_ENV
+            gem install bundler:1.17.3
       - restore_cache:
           keys:
             - gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
@@ -86,7 +92,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_4"
+        default: "ruby_2_6"
     steps:
       - pre-setup
       - bundle-install
@@ -96,7 +102,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_4"
+        default: "ruby_2_6"
     steps:
       - pre-setup
       - bundle-install
@@ -106,7 +112,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_4"
+        default: "ruby_2_6"
     steps:
       - pre-setup
       - bundle-install
@@ -114,25 +120,6 @@ jobs:
 
 workflows:
   version: 2
-  ruby_2_4:
-    jobs:
-      - bundle-audit:
-          name: "ruby-2_4-bundle_audit"
-      - rubocop:
-          name: "ruby-2_4-rubocop"
-      - rspec-unit:
-          name: "ruby-2_4-rspec"
-  ruby_2_5:
-    jobs:
-      - bundle-audit:
-          name: "ruby-2_5-bundle_audit"
-          e: "ruby_2_5"
-      - rubocop:
-          name: "ruby-2_5-rubocop"
-          e: "ruby_2_5"
-      - rspec-unit:
-          name: "ruby-2_5-rspec"
-          e: "ruby_2_5"
   ruby_2_6:
     jobs:
       - bundle-audit:
@@ -144,3 +131,25 @@ workflows:
       - rspec-unit:
           name: "ruby-2_6-rspec"
           e: "ruby_2_6"
+  ruby_2_7:
+    jobs:
+      - bundle-audit:
+          name: "ruby-2_7-bundle_audit"
+          e: "ruby_2_7"
+      - rubocop:
+          name: "ruby-2_7-rubocop"
+          e: "ruby_2_7"
+      - rspec-unit:
+          name: "ruby-2_7-rspec"
+          e: "ruby_2_7"
+  ruby_3_0:
+    jobs:
+      - bundle-audit:
+          name: "ruby-3_0-bundle_audit"
+          e: "ruby_3_0"
+      - rubocop:
+          name: "ruby-3_0-rubocop"
+          e: "ruby_3_0"
+      - rspec-unit:
+          name: "ruby-3_0-rspec"
+          e: "ruby_3_0"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
   Exclude:
     - spec/**/*
     - .bundle/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ Changelog for the gruf-sentry gem.
 
 ### Pending release
 
+### 0.2.0
+
+- Add support for Ruby 3.0
+- Remove support for < Ruby 2.6
+
 ### 0.1.1
 
 - Fix issue with options reference in ErrorParser [#1]

--- a/gruf-sentry.gemspec
+++ b/gruf-sentry.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.description   = spec.summary
   spec.homepage      = 'https://github.com/bigcommerce/gruf-sentry'
 
-  spec.required_ruby_version = '~> 2.4'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'gruf-sentry.gemspec']
   spec.require_paths = ['lib']

--- a/lib/gruf/sentry/version.rb
+++ b/lib/gruf/sentry/version.rb
@@ -17,6 +17,6 @@
 #
 module Gruf
   module Sentry
-    VERSION = '0.1.2.pre'
+    VERSION = '0.2.0.pre'
   end
 end


### PR DESCRIPTION
Adds support for Ruby 3.0. 

Deprecates support for < Ruby 2.6.

---

@bigcommerce/ruby @bigcommerce/oss-maintainers 