### PR TITLE
Update to sentry-ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog for the gruf-sentry gem.
 
 ### Pending release
 
+### 1.0.0
+
+- Update to sentry-ruby
+
 ### 0.2.0
 
 - Add support for Ruby 3.0

--- a/gruf-sentry.gemspec
+++ b/gruf-sentry.gemspec
@@ -35,16 +35,14 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'gruf-sentry.gemspec']
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'bundler-audit', '~> 0.6'
-  spec.add_development_dependency 'null-logger', '~> 0.1'
   spec.add_development_dependency 'rake', '>= 12.3'
-  spec.add_development_dependency 'rubocop', '~> 0.80'
-  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'rubocop', '>= 1'
+  spec.add_development_dependency 'pry', '~> 0.14'
   spec.add_development_dependency 'rspec', '>= 3.8'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.4'
-  spec.add_development_dependency 'simplecov', '~> 0.16'
+  spec.add_development_dependency 'simplecov', '>= 0.16'
 
   spec.add_dependency 'gruf', '~> 2.5', '>= 2.5.1'
-  spec.add_dependency 'sentry-raven', '>= 2.13'
+  spec.add_dependency 'sentry-ruby', '~> 4.3'
 end

--- a/lib/gruf/sentry.rb
+++ b/lib/gruf/sentry.rb
@@ -16,7 +16,10 @@
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 require 'gruf'
-require 'raven'
+require 'sentry-ruby'
+# backwards-compatibly patch for sentry-raven users
+::Raven = ::Sentry unless defined?(::Raven)
+
 require_relative 'sentry/version'
 require_relative 'sentry/configuration'
 require_relative 'sentry/error_parser'

--- a/lib/gruf/sentry/client_interceptor.rb
+++ b/lib/gruf/sentry/client_interceptor.rb
@@ -33,7 +33,7 @@ module Gruf
           yield
         rescue StandardError, GRPC::BadStatus => e
           if error?(e) # only capture
-            ::Raven.capture_exception(
+            ::Sentry.capture_exception(
               e,
               message: e.message,
               extra: {

--- a/lib/gruf/sentry/server_interceptor.rb
+++ b/lib/gruf/sentry/server_interceptor.rb
@@ -33,7 +33,7 @@ module Gruf
           yield
         rescue StandardError, GRPC::BadStatus => e
           if error?(e) # only capture
-            ::Raven.capture_exception(
+            ::Sentry.capture_exception(
               e,
               message: e.message,
               extra: {

--- a/script/test
+++ b/script/test
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+bundle install
+bundle exec rubocop -P -c ./.rubocop.yml
+bundle exec bundle-audit update
+bundle exec bundle-audit check
+bundle exec rspec

--- a/spec/gruf/sentry/server_interceptor_spec.rb
+++ b/spec/gruf/sentry/server_interceptor_spec.rb
@@ -49,7 +49,7 @@ describe Gruf::Sentry::ServerInterceptor do
       subject { interceptor.call { true } }
 
       it 'should not report the error' do
-        expect(Raven).to_not receive(:capture_exception)
+        expect(::Sentry).to_not receive(:capture_exception)
         expect { subject }.to_not raise_exception
       end
     end
@@ -67,7 +67,7 @@ describe Gruf::Sentry::ServerInterceptor do
 
       context 'and is a valid gRPC error' do
         it 'should ' do
-          expect(::Raven).to receive(:capture_exception).once
+          expect(::Sentry).to receive(:capture_exception).once
           expect { subject }.to raise_error(GRPC::Internal)
         end
       end
@@ -78,7 +78,7 @@ describe Gruf::Sentry::ServerInterceptor do
         end
 
         it 'should not report the error' do
-          expect(Raven).to_not receive(:capture_exception)
+          expect(::Sentry).to_not receive(:capture_exception)
           expect { subject }.to raise_error(GRPC::Internal)
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require_relative 'simplecov_helper'
 require 'grpc'
 require 'gruf'
@@ -25,11 +25,6 @@ require 'pry'
 Dir["#{File.join(File.dirname(__FILE__), 'support')}/**/*.rb"].each {|f| require f }
 
 RSpec.configure do |config|
-  config.alias_example_to 'fit', focus: true
-  config.filter_run focus: true
-  config.filter_run_excluding broken: true
-  config.run_all_when_everything_filtered = true
-  config.expose_current_running_example_as :example
   config.mock_with :rspec do |mocks|
     mocks.allow_message_expectations_on_nil = true
   end


### PR DESCRIPTION
## What?

- Update to sentry-ruby
- Add backwards-compat `Raven` constant
- Remove unnecessary dependencies
- Bump this lib to 1.0

---

@bigcommerce/ruby @bigcommerce/oss-maintainers 