### PR TITLE
Update Sentry.capture_exception to work with new sentry-ruby format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf-sentry gem.
 
 ### Pending release
 
+- Update Sentry.capture_exception to work with new sentry-ruby format
+
 ### 1.0.0
 
 - Update to sentry-ruby

--- a/spec/gruf/sentry/server_interceptor_spec.rb
+++ b/spec/gruf/sentry/server_interceptor_spec.rb
@@ -67,7 +67,7 @@ describe Gruf::Sentry::ServerInterceptor do
 
       context 'and is a valid gRPC error' do
         it 'should ' do
-          expect(::Sentry).to receive(:capture_exception).once
+          expect(::Sentry).to receive(:capture_exception).once.and_call_original
           expect { subject }.to raise_error(GRPC::Internal)
         end
       end


### PR DESCRIPTION
The Sentry dependency was updated recently (https://github.com/bigcommerce/gruf-sentry/pull/4), but the new version of Sentry has a new signature for `capture_exception` and the current implementation is resulting in errors like:

```
expected GRPC::Internal, got #<ArgumentError: unknown keyword: message> with backtrace:
    # ./lib/gruf/sentry/server_interceptor.rb:36:in `rescue in call'
    # ./lib/gruf/sentry/server_interceptor.rb:32:in `call'
    # ./spec/gruf/sentry/server_interceptor_spec.rb:65:in `block (4 levels) in <top (required)>'
    # ./spec/gruf/sentry/server_interceptor_spec.rb:78:in `block (6 levels) in <top (required)>'
    # ./spec/gruf/sentry/server_interceptor_spec.rb:78:in `block (5 levels) in <top (required)>'
    # ./spec/gruf/sentry/server_interceptor_spec.rb:78:in `block (5 levels) in <top (required)>'
```

From the [Sentry docs](https://docs.sentry.io/platforms/ruby/enriching-events/context/#additional-data),  it is preferred to instead update the context with structured data:

> In addition to structured contexts, Sentry supports adding unstructured "Additional Data" via set_extra. Additional Data is deprecated in favor of structured contexts and should be avoided when possible.

After updating the test to call `capture_exception` I was able to replicate this error. The new version of Sentry will not actually send the event unless the DSN has been set, so it should be safe to leave this in to catch method updates in the future.

Not committed, I added a `before` to set the DSN and push an event to our Sentry instance:

```
# something like:
::Sentry.init do |c|
  c.dsn = 'my dsn here'
end
```

Resulted in this event:
![image](https://user-images.githubusercontent.com/1090773/119036392-4d5aae00-b976-11eb-9c29-b9df014af374.png)
