### PR TITLE
Update Gruf::Sentry::ClientInterceptor for new sentry-ruby format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf-sentry gem.
 
 ### Pending release
 
+- Update Gruf::Sentry::ClientInterceptor for new sentry-ruby format
+
 ### 1.0.1
 
 - Update Sentry.capture_exception to work with new sentry-ruby format

--- a/spec/gruf/sentry/client_interceptor_spec.rb
+++ b/spec/gruf/sentry/client_interceptor_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2022-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+require 'spec_helper'
+
+describe Gruf::Sentry::ClientInterceptor do
+  let(:options) { {} }
+  let(:signature) { 'get_thing' }
+  let(:active_call) { grpc_active_call }
+  let(:grpc_method_name) { 'ThingService.get_thing' }
+  let(:request) do
+    double(
+      :request,
+      method_key: signature,
+      route_key: 'foo',
+      type: 'bar',
+      service: ThingService,
+      rpc_desc: nil,
+      active_call: active_call,
+      request_class: ThingRequest,
+      service_key: 'thing_service.thing_request',
+      message: grpc_request,
+      method_name: grpc_method_name
+    )
+  end
+  let(:interceptor) { described_class.new(options) }
+
+  describe '.call' do
+    context 'when there is no error' do
+      subject { interceptor.call(request_context: request) { true } }
+
+      it 'should not report the error' do
+        expect(::Sentry).to_not receive(:capture_exception)
+        expect { subject }.to_not raise_exception
+      end
+    end
+
+    context 'when there is an exception' do
+      let(:exception_class) { GRPC::Internal }
+      let(:error_message) { 'Something went wrong' }
+      let(:exception) { exception_class.new(error_message) }
+
+      subject do
+        interceptor.call(request_context: request) { raise exception }
+      end
+
+      context 'and is a valid gRPC error' do
+        it 'should ' do
+          expect(::Sentry).to receive(:capture_exception).once.and_call_original
+          expect { subject }.to raise_error(GRPC::Internal)
+        end
+      end
+
+      context 'with an ignored method' do
+        before do
+          allow(::Gruf::Sentry).to receive(:ignore_methods).and_return([grpc_method_name])
+        end
+
+        it 'should not report the error' do
+          expect(::Sentry).to_not receive(:capture_exception)
+          expect { subject }.to raise_error(GRPC::Internal)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Update `Gruf::Sentry::ClientInterceptor` for new sentry-ruby format.

Currently the `Gruf::Sentry::ClientInterceptor` returns an exception:

```ruby
ArgumentError: unknown keyword: :message
```

The reason is that, since https://github.com/getsentry/sentry-ruby/pull/1086 ([versions >= 4.0.0](https://github.com/getsentry/sentry-ruby/blob/sentry-ruby-v4.0.0/sentry-ruby/lib/sentry/scope.rb#L75-L89)) , the [API interface has changed](https://docs.sentry.io/platforms/ruby/guides/rails/migration/#api-changes) and `message` is no longer a valid keyword argument. The same issue was fixed in `Gruf::Sentry::ServerInterceptor` in https://github.com/bigcommerce/gruf-sentry/commit/81a3d4e5db76888f8067b538b43cdd0631ec01a8.

Adding a valid Sentry configuration in the `client_interceptor_spec.rb`, that actually tries to send the exception to Sentry, replicates the problem (in the original code):

```diff
diff --git a/spec/gruf/sentry/client_interceptor_spec.rb b/spec/gruf/sentry/client_interceptor_spec.rb
index 7c66d58..5787be4 100644
--- a/spec/gruf/sentry/client_interceptor_spec.rb
+++ b/spec/gruf/sentry/client_interceptor_spec.rb
@@ -40,6 +40,14 @@ describe Gruf::Sentry::ClientInterceptor do
   let(:interceptor) { described_class.new(options) }

   describe '.call' do
+    before do
+      Sentry.init do |config|
+        config.dsn = "<valid-dsn>"
+        config.enabled_environments = %w[test]
+        config.environment = 'test'
+      end
+    end
+
```

## Related links

* https://github.com/getsentry/sentry-ruby/pull/1086
* https://github.com/bigcommerce/gruf-sentry/commit/81a3d4e5db76888f8067b538b43cdd0631ec01a8
* https://github.com/getsentry/sentry-ruby/releases/tag/sentry-ruby-v4.0.0
* https://github.com/getsentry/sentry-ruby/blob/sentry-ruby-v4.0.0/sentry-ruby/lib/sentry/scope.rb#L75-L89