### PR TITLE
INFRA-9603: Upgrade to sentry-ruby 5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog for the gruf-sentry gem.
 
 ### Pending release
 
+### 1.3.x
+
+- Upgrade to sentry-ruby 5.x
+
 ### 1.2.0
 
 - Add Ruby 3.1 support

--- a/gruf-sentry.gemspec
+++ b/gruf-sentry.gemspec
@@ -38,11 +38,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler-audit', '~> 0.6'
   spec.add_development_dependency 'rake', '>= 12.3'
   spec.add_development_dependency 'rubocop', '>= 1.27'
-  spec.add_development_dependency 'pry', '~> 0.14'
+  spec.add_development_dependency 'pry', '>= 0.14'
   spec.add_development_dependency 'rspec', '>= 3.8'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.4'
   spec.add_development_dependency 'simplecov', '>= 0.16'
 
   spec.add_dependency 'gruf', '~> 2.5', '>= 2.5.1'
-  spec.add_dependency 'sentry-ruby', '~> 4.3'
+  spec.add_dependency 'sentry-ruby', '>= 5.0'
 end

--- a/lib/gruf/sentry/version.rb
+++ b/lib/gruf/sentry/version.rb
@@ -17,6 +17,6 @@
 #
 module Gruf
   module Sentry
-    VERSION = '1.2.1.pre'
+    VERSION = '1.3.0.pre'
   end
 end


### PR DESCRIPTION
Upgrades dependency to sentry-ruby 5.0+: https://github.com/getsentry/sentry-ruby/blob/master/CHANGELOG.md#500

Also loosens pry pin.