### PR TITLE
INFRA-9602: Add Zeitwerk

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,3 +51,7 @@ Metrics/BlockLength:
 
 Style/HashEachMethods:
   Enabled: false
+
+Naming/FileName:
+  Exclude:
+    - lib/gruf-sentry.rb

--- a/gruf-sentry.gemspec
+++ b/gruf-sentry.gemspec
@@ -15,7 +15,7 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'gruf/sentry/version'
 
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'gruf-sentry.gemspec']
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler-audit', '~> 0.6'
+  spec.add_development_dependency 'bundler-audit', '>= 0.6'
   spec.add_development_dependency 'rake', '>= 12.3'
   spec.add_development_dependency 'rubocop', '>= 1.27'
   spec.add_development_dependency 'pry', '>= 0.14'
@@ -43,6 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.4'
   spec.add_development_dependency 'simplecov', '>= 0.16'
 
-  spec.add_dependency 'gruf', '~> 2.5', '>= 2.5.1'
-  spec.add_dependency 'sentry-ruby', '>= 5.0'
+  spec.add_runtime_dependency 'gruf', '~> 2.5', '>= 2.5.1'
+  spec.add_runtime_dependency 'sentry-ruby', '>= 5.0'
+  spec.add_runtime_dependency 'zeitwerk', '~> 2'
 end

--- a/lib/gruf/sentry.rb
+++ b/lib/gruf/sentry.rb
@@ -17,14 +17,19 @@
 #
 require 'gruf'
 require 'sentry-ruby'
+
 # backwards-compatibly patch for sentry-raven users
 ::Raven = ::Sentry unless defined?(::Raven)
 
-require_relative 'sentry/version'
-require_relative 'sentry/configuration'
-require_relative 'sentry/error_parser'
-require_relative 'sentry/server_interceptor'
-require_relative 'sentry/client_interceptor'
+# use Zeitwerk to lazily autoload all the files in the lib directory
+require 'zeitwerk'
+root_path = File.dirname(__dir__)
+loader = ::Zeitwerk::Loader.new
+loader.tag = File.basename(__FILE__, '.rb')
+loader.inflector = ::Zeitwerk::GemInflector.new(__FILE__)
+loader.ignore(File.join(root_path, 'gruf-sentry.rb'))
+loader.push_dir(root_path)
+loader.setup
 
 ##
 # Base gruf module

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,10 +15,9 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require_relative 'simplecov_helper'
+
 require 'grpc'
-require 'gruf'
 require 'gruf-sentry'
 require 'pry'
 


### PR DESCRIPTION
## What?

Add [Zeitwerk](https://github.com/fxn/zeitwerk) for autoloading management of the library. This removes the need for us to manage LOAD_PATH in the library, and lowers memory usage (as now files are loaded on-demand.)