### PR TITLE
Remove `GRPC::FailedPrecondition` from default error classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog for the gruf-sentry gem.
 
 ### Pending release
 
+### 1.4.x
+
+* Remove `GRPC::FailedPrecondition` from default error classes (equivalent is HTTP 412, so not an internal error)
+
 ### 1.3.0
 
 - Upgrade to sentry-ruby 5.x

--- a/lib/gruf/sentry/configuration.rb
+++ b/lib/gruf/sentry/configuration.rb
@@ -24,7 +24,7 @@ module Gruf
       VALID_CONFIG_KEYS = {
         grpc_error_classes: ::ENV.fetch(
           'GRUF_SENTRY_GRPC_ERROR_CLASSES',
-          'GRPC::Unknown,GRPC::Internal,GRPC::DataLoss,GRPC::FailedPrecondition,GRPC::Unavailable,GRPC::DeadlineExceeded,GRPC::Cancelled'
+          'GRPC::Unknown,GRPC::Internal,GRPC::DataLoss,GRPC::Unavailable,GRPC::DeadlineExceeded,GRPC::Cancelled'
         ).to_s.split(',').map(&:strip),
         default_error_code: ::ENV.fetch('GRUF_SENTRY_DEFAULT_ERROR_CODE', GRPC::Core::StatusCodes::INTERNAL).to_i,
         ignore_methods: ::ENV.fetch('GRUF_SENTRY_IGNORE_METHODS', '').split(',').map(&:strip) || []


### PR DESCRIPTION
Since this is more of a HTTP 412, we shouldn't report on it as an internal error.
