### PR TITLE
Remove `Raven` compatibility layer; you must be on sentry-ruby now

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @bigcommerce/ruby
+* @bigcommerce/oss-maintainers

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+## What? Why?
+
+
+## How was it tested?

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "bigcommerce/ruby"
+      - "bigcommerce/oss-maintainers"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,36 +5,37 @@ Changelog for the gruf-sentry gem.
 ### 1.4.x
 
 * Remove `GRPC::FailedPrecondition` from default error classes (equivalent is HTTP 412, so not an internal error)
+* Remove `Raven` compatibility layer; you must be on sentry-ruby now
 
 ### 1.3.0
 
-- Upgrade to sentry-ruby 5.x
+* Upgrade to sentry-ruby 5.x
 
 ### 1.2.0
 
-- Add Ruby 3.1 support
-- Drop Ruby 2.6 support
+* Add Ruby 3.1 support
+* Drop Ruby 2.6 support
 
 ### 1.1.0
 
-- Update Gruf::Sentry::ClientInterceptor for new sentry-ruby format
+* Update Gruf::Sentry::ClientInterceptor for new sentry-ruby format
 
 ### 1.0.1
 
-- Update Sentry.capture_exception to work with new sentry-ruby format
+* Update Sentry.capture_exception to work with new sentry-ruby format
 
 ### 1.0.0
 
-- Update to sentry-ruby
+* Update to sentry-ruby
 
 ### 0.2.0
 
-- Add support for Ruby 3.0
-- Remove support for < Ruby 2.6
+* Add support for Ruby 3.0
+* Remove support for < Ruby 2.6
 
 ### 0.1.1
 
-- Fix issue with options reference in ErrorParser [#1]
+* Fix issue with options reference in ErrorParser [#1]
 
 ### 0.1.0
 

--- a/lib/gruf/sentry.rb
+++ b/lib/gruf/sentry.rb
@@ -18,9 +18,6 @@
 require 'gruf'
 require 'sentry-ruby'
 
-# backwards-compatibly patch for sentry-raven users
-::Raven = ::Sentry unless defined?(::Raven)
-
 # use Zeitwerk to lazily autoload all the files in the lib directory
 require 'zeitwerk'
 root_path = File.dirname(__dir__)

--- a/lib/gruf/sentry/version.rb
+++ b/lib/gruf/sentry/version.rb
@@ -17,6 +17,6 @@
 #
 module Gruf
   module Sentry
-    VERSION = '1.3.1.pre'
+    VERSION = '1.4.0.pre'
   end
 end


### PR DESCRIPTION
* Remove `Raven` backwards compatibility; you must now be on sentry-ruby.
* Add CODEOWNERS
* Add PR template
* Add dependabot config