### PR TITLE
Add support for Ruby 3.2, drop support for Ruby 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,6 @@ ruby_env: &ruby_env
     - image: cimg/ruby:<<parameters.ruby-version>>
 
 executors:
-  ruby_2_7:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "2.7"
   ruby_3_0:
     <<: *ruby_env
     parameters:
@@ -31,6 +25,12 @@ executors:
       ruby-version:
         type: string
         default: "3.1"
+  ruby_3_2:
+    <<: *ruby_env
+    parameters:
+      ruby-version:
+        type: string
+        default: "3.2"
 
 commands:
   pre-setup:
@@ -102,7 +102,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_7"
+        default: "ruby_3_0"
     steps:
       - pre-setup
       - bundle-install
@@ -112,7 +112,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_7"
+        default: "ruby_3_0"
     steps:
       - pre-setup
       - bundle-install
@@ -122,7 +122,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_7"
+        default: "ruby_3_0"
     steps:
       - pre-setup
       - bundle-install
@@ -130,17 +130,6 @@ jobs:
 
 workflows:
   version: 2
-  ruby_2_7:
-    jobs:
-      - bundle-audit:
-          name: "ruby-2_7-bundle_audit"
-          e: "ruby_2_7"
-      - rubocop:
-          name: "ruby-2_7-rubocop"
-          e: "ruby_2_7"
-      - rspec-unit:
-          name: "ruby-2_7-rspec"
-          e: "ruby_2_7"
   ruby_3_0:
     jobs:
       - bundle-audit:
@@ -163,3 +152,14 @@ workflows:
       - rspec-unit:
           name: "ruby-3_1-rspec"
           e: "ruby_3_1"
+  ruby_3_2:
+    jobs:
+      - bundle-audit:
+          name: "ruby-3_2-bundle_audit"
+          e: "ruby_3_2"
+      - rubocop:
+          name: "ruby-3_2-rubocop"
+          e: "ruby_3_2"
+      - rspec-unit:
+          name: "ruby-3_2-rspec"
+          e: "ruby_3_2"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,3 +55,6 @@ Style/HashEachMethods:
 Naming/FileName:
   Exclude:
     - lib/gruf-sentry.rb
+
+Style/RedundantConstantBase:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog for the gruf-sentry gem.
 
 ### Pending release
 
+- Add support for Ruby 3.2
+- Drop support for Ruby 2.7 (EOL March 2023)
+
 ### 1.4.0
 
 * Remove `GRPC::FailedPrecondition` from default error classes (equivalent is HTTP 412, so not an internal error)

--- a/gruf-sentry.gemspec
+++ b/gruf-sentry.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.description   = spec.summary
   spec.homepage      = 'https://github.com/bigcommerce/gruf-sentry'
 
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = '>= 3.0', '< 4'
 
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'gruf-sentry.gemspec']
   spec.require_paths = ['lib']


### PR DESCRIPTION
## What? Why?

* Add tested support for Ruby 3.2
* Drops support for Ruby 2.7 (EOL March 2023)

## How was it tested?

rspec, local