### PR TITLE
Add Ruby 3.4 support, drop EOL Ruby 3.0/3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,18 +13,6 @@ ruby_env: &ruby_env
     - image: cimg/ruby:<<parameters.ruby-version>>
 
 executors:
-  ruby_3_0:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "3.0"
-  ruby_3_1:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "3.1"
   ruby_3_2:
     <<: *ruby_env
     parameters:
@@ -37,6 +25,12 @@ executors:
       ruby-version:
         type: string
         default: "3.3"
+  ruby_3_4:
+    <<: *ruby_env
+    parameters:
+      ruby-version:
+        type: string
+        default: "3.4"
 
 commands:
   pre-setup:
@@ -108,7 +102,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_3_0"
+        default: "ruby_3_2"
     steps:
       - pre-setup
       - bundle-install
@@ -118,7 +112,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_3_0"
+        default: "ruby_3_2"
     steps:
       - pre-setup
       - bundle-install
@@ -128,7 +122,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_3_0"
+        default: "ruby_3_2"
     steps:
       - pre-setup
       - bundle-install
@@ -136,28 +130,6 @@ jobs:
 
 workflows:
   version: 2
-  ruby_3_0:
-    jobs:
-      - bundle-audit:
-          name: "ruby-3_0-bundle_audit"
-          e: "ruby_3_0"
-      - rubocop:
-          name: "ruby-3_0-rubocop"
-          e: "ruby_3_0"
-      - rspec-unit:
-          name: "ruby-3_0-rspec"
-          e: "ruby_3_0"
-  ruby_3_1:
-    jobs:
-      - bundle-audit:
-          name: "ruby-3_1-bundle_audit"
-          e: "ruby_3_1"
-      - rubocop:
-          name: "ruby-3_1-rubocop"
-          e: "ruby_3_1"
-      - rspec-unit:
-          name: "ruby-3_1-rspec"
-          e: "ruby_3_1"
   ruby_3_2:
     jobs:
       - bundle-audit:
@@ -180,3 +152,14 @@ workflows:
       - rspec-unit:
           name: "ruby-3_3-rspec"
           e: "ruby_3_3"
+  ruby_3_4:
+    jobs:
+      - bundle-audit:
+          name: "ruby-3_4-bundle_audit"
+          e: "ruby_3_4"
+      - rubocop:
+          name: "ruby-3_4-rubocop"
+          e: "ruby_3_4"
+      - rspec-unit:
+          name: "ruby-3_4-rspec"
+          e: "ruby_3_4"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @bigcommerce/ruby
-* @bigcommerce/oss-maintainers
+* @bigcommerce/ruby @bigcommerce/oss-maintainers

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,6 @@
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.2
   NewCops: enable
-  SuggestExtensions: false
   Exclude:
     - spec/**/*
     - .bundle/**/*
@@ -11,25 +10,25 @@ AllCops:
     - log/**/*
     - Rakefile
     - gruf-sentry.gemspec
+plugins:
+  - rubocop-packaging
+  - rubocop-performance
+  - rubocop-rake
+  - rubocop-rspec
+  - rubocop-thread_safety
 
+
+# Allow *VALID_CONFIG_KEYS.keys
 Lint/AmbiguousOperator:
   Exclude:
     - lib/gruf/sentry/configuration.rb
 
-Layout/EndAlignment:
-  Enabled: false
+# This cop conflicts with other cops
+Layout/LineLength:
+  Max: 140
 
 Metrics/AbcSize:
   Max: 147
-
-Metrics/ClassLength:
-  Max: 406
-
-Metrics/CyclomaticComplexity:
-  Max: 12
-
-Layout/LineLength:
-  Max: 140
 
 Metrics/MethodLength:
   Max: 88
@@ -43,18 +42,6 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Max: 12
 
-Naming/PredicateName:
-  Enabled: false
-
-Metrics/BlockLength:
-  Enabled: false
-
-Style/HashEachMethods:
-  Enabled: false
-
 Naming/FileName:
   Exclude:
     - lib/gruf-sentry.rb
-
-Style/RedundantConstantBase:
-  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ Changelog for the gruf-sentry gem.
 
 ### Pending release
 
-- Add CI suite for Ruby 3.3
+- Add support for Ruby 3.4, 3.3
+- Drop support for Ruby 3.0, 3.1
 
 ### 1.5.0
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,18 @@
 #
 source 'https://rubygems.org'
 
+gem 'bundler-audit', '>= 0.6'
+gem 'pry', '>= 0.14'
+gem 'rake', '>= 12.3'
+gem 'reline'
+gem 'rspec', '>= 3.8'
+gem 'rspec_junit_formatter', '~> 0.4'
+gem 'rubocop', '>= 1.27'
+gem 'rubocop-packaging'
+gem 'rubocop-performance'
+gem 'rubocop-rake'
+gem 'rubocop-rspec'
+gem 'rubocop-thread_safety'
+gem 'simplecov', '>= 0.16'
+
 gemspec

--- a/bin/console
+++ b/bin/console
@@ -16,5 +16,5 @@
 #
 require 'bundler/setup'
 require 'gruf/sentry'
-require 'irb'
-IRB.start(__FILE__)
+require 'pry'
+Pry.start(__FILE__)

--- a/gruf-sentry.gemspec
+++ b/gruf-sentry.gemspec
@@ -35,14 +35,6 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'gruf-sentry.gemspec']
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler-audit', '>= 0.6'
-  spec.add_development_dependency 'rake', '>= 12.3'
-  spec.add_development_dependency 'rubocop', '>= 1.27'
-  spec.add_development_dependency 'pry', '>= 0.14'
-  spec.add_development_dependency 'rspec', '>= 3.8'
-  spec.add_development_dependency 'rspec_junit_formatter', '~> 0.4'
-  spec.add_development_dependency 'simplecov', '>= 0.16'
-
   spec.add_runtime_dependency 'gruf', '~> 2.5', '>= 2.5.1'
   spec.add_runtime_dependency 'sentry-ruby', '>= 5.0'
   spec.add_runtime_dependency 'zeitwerk', '~> 2'

--- a/lib/autoloader.rb
+++ b/lib/autoloader.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# use Zeitwerk to lazily autoload all the files in the lib directory
+require 'zeitwerk'
+loader = Zeitwerk::Loader.for_gem(warn_on_extra_files: false)
+loader.ignore(File.join(__dir__.to_s, 'gruf-sentry.rb'))
+loader.setup

--- a/lib/gruf/sentry.rb
+++ b/lib/gruf/sentry.rb
@@ -17,16 +17,7 @@
 #
 require 'gruf'
 require 'sentry-ruby'
-
-# use Zeitwerk to lazily autoload all the files in the lib directory
-require 'zeitwerk'
-root_path = File.dirname(__dir__)
-loader = ::Zeitwerk::Loader.new
-loader.tag = File.basename(__FILE__, '.rb')
-loader.inflector = ::Zeitwerk::GemInflector.new(__FILE__)
-loader.ignore(File.join(root_path, 'gruf-sentry.rb'))
-loader.push_dir(root_path)
-loader.setup
+require_relative '../autoloader'
 
 ##
 # Base gruf module

--- a/lib/gruf/sentry/server_interceptor.rb
+++ b/lib/gruf/sentry/server_interceptor.rb
@@ -26,7 +26,7 @@ module Gruf
       ##
       # Handle the gruf around hook and capture errors
       #
-      def call(&_block)
+      def call(&)
         return yield if Gruf::Sentry.ignore_methods.include?(request.method_name)
 
         begin

--- a/lib/gruf/sentry/version.rb
+++ b/lib/gruf/sentry/version.rb
@@ -17,6 +17,6 @@
 #
 module Gruf
   module Sentry
-    VERSION = '1.5.1.pre'
+    VERSION = '1.6.0.pre'
   end
 end


### PR DESCRIPTION
## What? Why?

- Add support for Ruby 3.4, 3.3
- Drop support for Ruby 3.0, 3.1

## How was it tested?

Unit suite passes.