### PR TITLE
Fix issue with autoloading in eager loaded Rails envs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-* @bigcommerce/ruby @bigcommerce/oss-maintainers
+* @bigcommerce/ruby
+* @bigcommerce/oss-maintainers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf-sentry gem.
 
 ### Pending release
 
+- Fix autoloading issue in certain Rails environments
+
 ## 1.6.0
 
 - Add support for Ruby 3.4, 3.3

--- a/gruf-sentry.gemspec
+++ b/gruf-sentry.gemspec
@@ -33,9 +33,9 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0', '< 4'
 
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'gruf-sentry.gemspec']
-  spec.require_paths = ['lib']
+  spec.require_paths = %w[lib]
 
   spec.add_runtime_dependency 'gruf', '~> 2.5', '>= 2.5.1'
   spec.add_runtime_dependency 'sentry-ruby', '>= 5.0'
-  spec.add_runtime_dependency 'zeitwerk', '~> 2'
+  spec.add_runtime_dependency 'zeitwerk', '>= 2'
 end

--- a/lib/autoloader.rb
+++ b/lib/autoloader.rb
@@ -2,6 +2,11 @@
 
 # use Zeitwerk to lazily autoload all the files in the lib directory
 require 'zeitwerk'
+lib_dir = __dir__.to_s
 loader = Zeitwerk::Loader.for_gem(warn_on_extra_files: false)
-loader.ignore(File.join(__dir__.to_s, 'gruf-sentry.rb'))
+loader.inflector.inflect('version' => 'VERSION')
+loader.ignore(
+  File.join(lib_dir, 'gruf-sentry.rb'),
+  File.join(lib_dir, 'autoloader.rb')
+)
 loader.setup


### PR DESCRIPTION
## What/Why?

Fixes an issue where eager loading and rails' use of zeitwerk cause a constant not found issue, due to some files not being ignored by zeitwerk's usage in this gem.

## Rollout/Rollback

Revert.

## Testing

Tested on a Rails app. Works as expected.